### PR TITLE
RF-18 Movement Cards almost fully implemented (missing endpoint and api connection)

### DIFF
--- a/Anura/anura-schema.sql
+++ b/Anura/anura-schema.sql
@@ -16,7 +16,7 @@ CREATE TABLE cards(
     card_name VARCHAR(50) NOT NULL,
     card_cost SMALLINT UNSIGNED NOT NULL,
     card_type VARCHAR(25) NOT NULL,
-    effect_value SMALLINT UNSIGNED DEFAULT 0,
+    effect_value DECIMAL(5,2) UNSIGNED DEFAULT 0,
     effect_parameter VARCHAR(30) NOT NULL,
     card_description VARCHAR(250) NOT NULL,
     updated_at TIMESTAMP DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP

--- a/Anura/anura-seed.sql
+++ b/Anura/anura-seed.sql
@@ -20,8 +20,8 @@ INSERT IGNORE INTO playable_character (pc_user_id, character_name, base_hp, base
 INSERT IGNORE INTO cards (card_name, card_cost, card_type, effect_value, effect_parameter, card_description) VALUES
 
 -- MOVEMENT CARDS
-('Iron Hindlegs', 15, 'Movement', 1, 'canDoubleJump', 'Grants the frog a double jump.'),
-('Dragonfly Hop', 10, 'Movement', 1, 'canDoubleJump', 'A light hop inspired by dragonflies.'),
+('Iron Hindlegs', 15, 'Movement', 1, 'extraJumps', 'Grants the frog a double jump.'),
+('Dragonfly Hop', 10, 'Movement', 2, 'extraJumps', 'Replaces normal jump with three rapid micro jumps.'),
 ('Glide Membrane', 20, 'Movement', 1, 'canGlide', 'Allows the frog to glide through the air.'),
 ('Bubble Dash', 5, 'Movement', 1, 'canDash', 'A quick dash encased in a bubble.'),
 ('Rocket Frog', 25, 'Movement', 2, 'jumpForce', 'Launches the frog with rocket power.'),

--- a/Anura/anura-seed.sql
+++ b/Anura/anura-seed.sql
@@ -4,20 +4,20 @@
 
 USE anura;
 
--- TEST USERS (for local development only)
-INSERT INTO users (username, email, password) VALUES
+-- TEST USERS (for local development only) REMOVE LATER
+INSERT IGNORE INTO users (username, email, password) VALUES
 ('Renata', 'renata@mail.com', '1234'),
 ('Carlos', 'carlos@mail.com', '1234'),
 ('Emilio', 'emilio@mail.com', '1234');
 
--- TEST PLAYABLE CHARACTERS (one per user)
-INSERT INTO playable_character (pc_user_id, character_name, base_hp, base_speed, base_damage) VALUES
+-- TEST PLAYABLE CHARACTERS (one per user) REMOVE LATER
+INSERT IGNORE INTO playable_character (pc_user_id, character_name, base_hp, base_speed, base_damage) VALUES
 (1, 'Froggy_Renata', 100, 10, 15),
 (2, 'Froggy_Carlos', 100, 10, 15),
 (3, 'Froggy_Emilio', 100, 10, 15);
 
 -- CARDS
-INSERT INTO cards (card_name, card_cost, card_type, effect_value, effect_parameter, card_description) VALUES
+INSERT IGNORE INTO cards (card_name, card_cost, card_type, effect_value, effect_parameter, card_description) VALUES
 
 -- MOVEMENT CARDS
 ('Iron Hindlegs', 15, 'Movement', 1, 'canDoubleJump', 'Grants the frog a double jump.'),

--- a/Anura/js/cards.js
+++ b/Anura/js/cards.js
@@ -54,100 +54,134 @@ function getImageByName(name) {
     return img;
 
 }
-// --- MOVEMENT CARD DEFINITIONS ---
 
-let ironHindlegs = {
-    card_id: 1,
-    name: "Iron Hindlegs",
-    category: "Movement",
-    cost: 15,
-    description: "Grants the frog a double jump.",
-    effect: function() {
-        frog.canDoubleJump = true;
-        frog.hasDoubleJump = true;
-    },
+// --- FROG BASE VALUES
+// copies the frog constructor defaults for every property a card can touch
+// reset() uses these to know what value to restore the frog to
+// if a default value in frog.js constructor it must be updated here too
 
-    reset: function() {
-        frog.canDoubleJump = false
-        frog.hasDoubleJump = false;
-    },
-
-    image: getImageByName("Iron Hindlegs")
+const FROG_BASE_VALUES = {
+    extraJumps:     0, // no extra jumps by default
+    jumpsRemaining: 0, // no jumps remaining by default
+    canGlide: false, // glide locked by default
+    canDash: false, // dash locked by default
+    jumpForce: -15, // must match frog.js constructor exactly
 };
 
 
-let dragonflyHop = {
-    card_id: 2,
-    name: "Dragonfly Hop",
-    category: "Movement",
-    cost: 10,
-    description: "Grants the frog a double jump.",
-    effect: function() {
-        console.log("Dragonfly hop test card");
+// --- CARD BASE ---
+// this function takes a card from the database and turns it into a usable card object
+// it makes the effect() and reset() functions automatically using the DB data
+// so hardcode shouldn't happen for any card here
+// to add a new card in the future, just add a new row to the database so not new code at all :D
+
+function createCardFromDatabase(dbCard) {
+
+    // param = the frog property that the card will change (e.g. canGlide, extraJumps, etc)
+    // cardValue = the number stored in the database for this card
+    const param = dbCard.effect_parameter;
+    const cardValue = dbCard.effect_value;
+
+    // db only stores numbers, but some frog properties are true/false values
+    // FROG_BASE_VALUES is checked to see what type the property should be
+    // true/false -> convert the DB number 1 to true
+    // number -> keep it as a number
+
+    const isBoolean   = param in FROG_BASE_VALUES && typeof FROG_BASE_VALUES[param] === "boolean";
+    const effectValue = isBoolean ? Boolean(cardValue) : cardValue;
+
+    // Rocket Frog is different, its DB value is a multiplier, not a direct value
+    // effect_value: 2 means multiply the base jump force by 2
+    const isMultiplier = (param === "jumpForce");
+
+     return {
+        card_id:          dbCard.card_id,
+        name:             dbCard.card_name,
+        category:         dbCard.card_type,
+        cost:             dbCard.card_cost,
+        description:      dbCard.card_description,
+        effect_parameter: param,
+        effect_value:     effectValue,
+        image:            getImageByName(dbCard.card_name),
+
+        // effect() runs when the player burns this card 
+        effect() {
+            if (isMultiplier) {
+                // rocket frog -> multiply base jumpForce by 2 for example
+                frog[param] = FROG_BASE_VALUES[param] * effectValue;
+
+            } else {
+                // all other cards directly set the frog property to true true false etc
+                frog[param] = effectValue;
+
+                // extra jumps needs jumpsRemaining updated asap so the player can use them without landing
+                if (param === "extraJumps") frog.jumpsRemaining = effectValue;
+            }
+        },
+
+        // reset() runs when the player burns a new card replacing this one or when the run ends
+        reset() {
+            frog[param] = FROG_BASE_VALUES[param];
+
+            // if we reset extraJumps, also clear jumpsRemaining
+            // so no leftover jumps stay after the card is gone
+            if (param === "extraJumps") frog.jumpsRemaining = 0;
+
+            // if we reset canDash also stop any dash happening right now
+            // this prevents the frog from dashing forever if the card is replaced mid-dash
+            if (param === "canDash") {
+                frog.isDashing = false;
+                frog.dashTimer = 0;
+            }
+        }
     }
-};
+}
 
-let glideMembrane = {
-    card_id: 3,
-    name: "Glide Membrane",
-    category: "Movement",
-    cost: 20,
-    description: "Grants the frog a double jump.",
-    effect: function() {
-        console.log("Glide Membrane");
+// --- CLEAR ALL MOVEMENT EFFECTS ---
+// this runs when the player dies or starts a new game
+// it makes sure the frog goes back to its normal state with no card abilities active
+
+function clearAllMovementEffects() {
+
+    // first try to use the last burned card's own reset function
+    if (lastBurnedSlot1 && lastBurnedSlot1.reset) {
+        lastBurnedSlot1.reset();
     }
-};
+    lastBurnedSlot1 = null;
 
-let bubbleDash = {
-    card_id: 4,
-    name: "Bubble Dash",
-    category: "Movement",
-    cost: 5,
-    description: "Grants the frog a double jump.",
-    effect: function() {
-        console.log("Bubble Dash");
+    // for safety issues, manually restore every frog property to its base value, handling cases like player dying before burning a card
+    if (frog) {
+        for (const [param, baseValue] of Object.entries(FROG_BASE_VALUES)) {
+            frog[param] = baseValue;
+        }
+        // also reset the states that are not in FROG_BASE_VALUES
+        frog.isDashing              = false;  // stop any active dash
+        frog.dashTimer              = 0;      // clear dash timer
+        frog.isGliding              = false;  // stop any active glide
+        frog.extraJumpCooldownTimer = 0;      // clear jump cooldown
     }
-};
 
-let rocketFrog = {
-    card_id: 5,
-    name: "Rocket Frog",
-    category: "Movement",
-    cost: 25,
-    description: "Grants the frog a double jump.",
-    effect: function() {
-        console.log("Rocket Frog");
-    }
-};
-
-ironHindlegs.image = getImageByName(ironHindlegs.name);
-dragonflyHop.image = getImageByName(dragonflyHop.name);
-glideMembrane.image = getImageByName(glideMembrane.name);
-bubbleDash.image = getImageByName(bubbleDash.name);
-rocketFrog.image = getImageByName(rocketFrog.name);
-
-
+    console.log("All movement effects cleared.");
+}
 
 // --- DECK ---
 
 let deck = {
     slot1_Movement: [],
     slot2_Combat: [],
-    slot3_Utility: []
-
-    
+    slot3_Utility: []  
 };
 
-deck.slot1_Movement.push(ironHindlegs);
-deck.slot1_Movement.push(dragonflyHop);
-deck.slot1_Movement.push(glideMembrane);
-deck.slot1_Movement.push(bubbleDash);
-deck.slot1_Movement.push(rocketFrog);
+// --- CARD POOL ---
+let cardPool = [
+    createCardFromDatabase({ card_id: 1, card_name: "Iron Hindlegs",  card_type: "Movement", card_cost: 15, effect_value: 1, effect_parameter: "extraJumps", card_description: "Grants the frog a double jump." }),
+    createCardFromDatabase({ card_id: 2, card_name: "Dragonfly Hop",  card_type: "Movement", card_cost: 10, effect_value: 2, effect_parameter: "extraJumps", card_description: "Replaces normal jump with three rapid micro jumps." }),
+    createCardFromDatabase({ card_id: 3, card_name: "Glide Membrane", card_type: "Movement", card_cost: 20, effect_value: 1, effect_parameter: "canGlide",   card_description: "Allows the frog to glide through the air." }),
+    createCardFromDatabase({ card_id: 4, card_name: "Bubble Dash",    card_type: "Movement", card_cost: 5,  effect_value: 1, effect_parameter: "canDash",    card_description: "A quick dash encased in a bubble." }),
+    createCardFromDatabase({ card_id: 5, card_name: "Rocket Frog",    card_type: "Movement", card_cost: 25, effect_value: 1.5, effect_parameter: "jumpForce",  card_description: "Launches the frog with rocket power." }),
+];
 
-// CARD POOL
-let cardPool = [ironHindlegs, dragonflyHop, glideMembrane, bubbleDash, rocketFrog];
-
-
-
+// loadDeck() will replace this when the API is connected
+deck.slot1_Movement = [...cardPool];
 
 

--- a/Anura/js/entities/frog.js
+++ b/Anura/js/entities/frog.js
@@ -24,15 +24,21 @@ class Frog extends AnimatedObject {
         this.gravity = 0.8;
         this.jumpForce = -15;
 
-        // --- DOUBLE JUMP ---
-        this.canDoubleJump = false;
-        this.hasDoubleJump = false;
-        this.doubleJumpCooldown = 3000;
-        this.doubleJumpCooldownTimer = 0;
+        // --- EXTRA JUMPS ---
+        this.extraJumps = 0; // set by card: Iron Hindlegs = 1, Dragonfly Hop = 2
+        this.jumpsRemaining = 0; 
+        this.extraJumpCooldown = 150; // 3 sec between extra jumps
+        this.extraJumpCooldownTimer = 0;
+
+        // --- GLIDE ---
+        this.canGlide = false; 
+        this.isGliding = false;
+        this.glideGravity = 0.01; 
 
         // --- DASH ---
+        this.canDash = false; // used in Bubble Dash card
         this.dashSpeed = 15;
-        this.dashDuration = 150;
+        this.dashDuration = 300;
         this.dashTimer = 0;
         this.dashCooldown = 3000;
         this.dashCooldownTimer = 0;
@@ -70,7 +76,7 @@ class Frog extends AnimatedObject {
         this.updateFrame(deltaTime);
 
         // --- TIMERS ---
-        if (this.doubleJumpCooldownTimer > 0) this.doubleJumpCooldownTimer -= deltaTime;
+        if (this.extraJumpCooldownTimer > 0) this.extraJumpCooldownTimer -= deltaTime;
         if (this.dashTimer > 0) {
             this.dashTimer -= deltaTime;
             if (this.dashTimer <= 0) { 
@@ -105,9 +111,22 @@ class Frog extends AnimatedObject {
         }
 
         // --- VERTICAL MOVEMENT (GRAVITY) ---
-        this.velocityY += this.gravity * (deltaTime / 16);
-        if (this.velocityY > 20) this.velocityY = 20; // Terminal velocity limit
-        this.position.y += this.velocityY * (deltaTime / 16);
+
+        // sets gliding to true if ALL four conditions are true at the same time
+        this.isGliding = this.canGlide && !this.isOnGround && this.velocityY > 0 && (keys["s"] || keys["S"]); //  player burns card, frog on air, frog falling down, keys are active
+
+        let activeGravity; // gravity value
+
+        if (this.isGliding) { //if frog is gliding
+            activeGravity = this.glideGravity; // 0.1 slow fall
+        } else {
+            activeGravity = this.gravity; // normal fall
+        }
+
+        // gravity applied, every frame we add a bit more pull down to the vertical speed,
+        this.velocityY += activeGravity * (deltaTime / 16);
+        if (this.velocityY > 20) this.velocityY = 20; // Terminal velocity limit, without it the frog would fall faster forever with no limit, so if VelocityY tries to exceed it, it goes back to 20
+        this.position.y += this.velocityY * (deltaTime / 16); // move frog, if velocitY is + = frog moves down, else if negative, it would move up
 
         // --- SIMPLE PLATFORM COLLISION ---
         // --- FULL SOLID PLATFORM COLLISION  ---
@@ -148,8 +167,8 @@ class Frog extends AnimatedObject {
                         this.velocityY = 0;
                         this.isOnGround = true;
                         
-                        // Reset double jump mechanics
-                        if (this.canDoubleJump) this.hasDoubleJump = true;
+                        // reset extra jumps on landing
+                        this.jumpsRemaining = this.extraJumps;
                     }
                 }
             }
@@ -161,7 +180,8 @@ class Frog extends AnimatedObject {
             this.position.y = groundLimitY;
             this.velocityY = 0;
             this.isOnGround = true;
-            if (this.canDoubleJump) this.hasDoubleJump = true;
+            // reset extra jumps on landing
+            this.jumpsRemaining = this.extraJumps;
         }
 
         // Camera limit (Prevent moving backwards off-screen)

--- a/Anura/js/scenes/playScene.js
+++ b/Anura/js/scenes/playScene.js
@@ -48,8 +48,10 @@ function handleKeyDown(event) {
 // gameOver function that awaits for the server
 async function gameOver() {
     if (isGameOver) return; // if game is already over, do nothing, prevents double triggers
-    
     isGameOver = true; // sets gameOver to true
+
+    // clear all card effects, so the frog returns to base state on death
+    clearAllMovementEffects();
 
     // gameloop running check
     // stop game loop so the game freezes when the player dies
@@ -211,24 +213,27 @@ window.addEventListener('keydown', (event) => {
     if (event.key === ' ' && frog.isOnGround) { 
         frog.velocityY = frog.jumpForce; // set vertical speed 
         frog.isOnGround = false;
-    // DOUBLE JUMP
-    } else if (event.key === ' ' && frog.canDoubleJump && frog.hasDoubleJump && frog.doubleJumpCooldownTimer <= 0 && !frog.isOnGround) { // space was pressed and the ability is unlocked and a double jump is still available and frog is in the air
-        frog.hasDoubleJump = false; // double jump consumed
-        frog.doubleJumpCooldownTimer = frog.doubleJumpCooldown; // start the cooldown
+
+    // DOUBLE AND TRIPLE JUMP
+
+    } else if (event.key === ' ' && !frog.isOnGround && frog.jumpsRemaining > 0 && frog.extraJumpCooldownTimer <= 0) {
+        frog.jumpsRemaining--; // consume one jump charge
+        frog.extraJumpCooldownTimer = frog.extraJumpCooldown; // start cooldown
         frog.velocityY = 0; // cancel downward velocity so the jump is clean
-        frog.velocityY = frog.jumpForce * 1; // stronger jump force
+        frog.velocityY = frog.jumpForce; // stronger jump force
         frog.isOnGround = false;
     }
 
     // dash (j key)
+    // requires Bubble Dash card to be active (canDash)
     // !event.repeat → only triggers on the first key press (not when holding the key)
-    // only works if there's no active dash and the cooldown finished
-    if (event.key === 'j' && !event.repeat && !frog.isDashing && frog.dashCooldownTimer <= 0) {
-        frog.color = "blue";
-
+    // protective bubble gives invincibility for the duration of the dash
+    if (event.key === 'j' && !event.repeat && frog.canDash && !frog.isDashing && frog.dashCooldownTimer <= 0) {
         frog.isDashing = true;
-        frog.dashTimer = frog.dashDuration; 
+        frog.dashTimer = frog.dashDuration;
         frog.dashCooldownTimer = frog.dashCooldown;
+        frog.invincibilityTimer = frog.dashDuration; // protective bubble lasts as long as the dash
+        console.log("Bubble Dash activated — invincibility active for", frog.dashDuration, "ms");
     }
 
     // attack (i key)
@@ -339,6 +344,11 @@ function beginRun() {
 
     if (frog) {
         frog.invincibilityTimer = 0; 
+
+        // clear any card effects left over from the previous run
+        // so the frog always starts fresh with no active abilities
+        clearAllMovementEffects();
+
     } // resetting the timer for every new run
 
 

--- a/Anura/js/systems/hud.js
+++ b/Anura/js/systems/hud.js
@@ -155,4 +155,13 @@ function drawCardHUD(deck) {
     drawCard(startX, startY, deck.slot1_Movement[0], "1", slot1FlashTimer);
     drawCard(startX + cardWidth + spacing, startY, deck.slot2_Combat[0], "2", slot2FlashTimer);
     drawCard(startX + (cardWidth + spacing) * 2, startY, deck.slot3_Utility[0], "3", slot3FlashTimer);
+
+    // ACTIVE EFFECT -> shows which card is currently active on the frog
+    if (lastBurnedSlot1) {
+        ctx.fillStyle = "lime";
+        ctx.font = "10px Pixelify Sans";
+        ctx.textAlign = "left";
+        ctx.fillText("ACTIVE: " + lastBurnedSlot1.name, startX, startY + cardHeight + 20);
+    }
+
 }


### PR DESCRIPTION
- Implemented the full Movement cards system
- Replaced `canDoubleJump` and `hasDoubleJump` in `frog.js` with a jump counter system `extraJumps` and `jumpsRemaining` this allows Iron Hindlegs card to obtain 1 extra jump (2 jumps total) and Dragonfly Hop to obtain 2 extra jumps (3 jumps total)
- Added `canGlide`, `isGliding` , `glideGravity` for the Glide Membrane card
- Added `canDash` so the frog can only dash after activating bubble dash card
- Dash is now a card Movement ability only, not a default movement
- Updated physics loop so there's reduced gravity when the frog is gliding for the Glide Membrane card
- Updated the landing detection so it resets `jumpsRemaining` when the frog touches the ground its extra jumps are restored so they can be used again on the next jump
- added `clearAllMovementEffects` in `beginRun` and `gameOver` to reset abilities on run end

- Removed hardcoded card objects, now everything is set up to come from the backend (AWAITING ENDPOINTS FOR THIS) but technically it should work when api is connected to this part
- Added `FROG_BASE_VALUES` which is a list of the frogs default values, it is used to restore the frog back to normal when a card is reset
- Added `createCardFromDatabase(dbCard)` which is a function that takes a card from the database and turns it into an object with effect and reset methods, this is made this way so in the future, adding a card only requires a new row in the db.
- Added `clearAllMovementEffects()` which again resets all active abilities on the frog when the run ends as mentioned before
- The `cardPool` now uses the `createCardFromDatabase(dbCard)` function with values from the `anura-seed.sql` file exactly just to test it until the API is connected.
- Changed `effect_parameter` from `canDoubleJump` to `extraJumps` for Iron Hindlegs and Dragonfly Hop on anura-seed
- Changed `effect_value` column type from `SMALLINT` to `DECIMAL(5,2) UNSIGNED` so we can use decimal numbers used as multipliers like 1.5 like we did for one of the Movement cards.
- On the hud added an indicator to see which card ability is active on the frog