### PR TITLE
implemented victory tracking system with stats sidebar

### DIFF
--- a/Anura/anura-seed.sql
+++ b/Anura/anura-seed.sql
@@ -152,6 +152,25 @@ USE anura;
 	END$$
 	DELIMITER ;
 
+
+	-- TRIGGER for calulating run_time when a run is UPDATED (victory/death)
+	-- Needed because the existing trigger calculateRunTime only fires on INSERT (run start), 
+	-- but run_time needs to be calculated when end_time is set during 
+	-- UPDATE (when saveRun procedure is called with victory status)
+	-- IDENTIFIED WITH AI, I asked AI what the problem was and why was the run time not updating, and it pointed this out
+	DROP TRIGGER IF EXISTS calculateRunTimeOnUpdate;
+	DELIMITER $$
+	CREATE TRIGGER calculateRunTimeOnUpdate
+	BEFORE UPDATE ON anura.runs
+	FOR EACH ROW
+	BEGIN
+		-- if end_time was just set victory or death, calculate the run time
+		IF NEW.end_time IS NOT NULL AND OLD.end_time IS NULL THEN
+			SET NEW.run_time = TIMESTAMPDIFF(SECOND, NEW.start_time, NEW.end_time);
+		END IF;
+	END$$
+	DELIMITER ;
+
 	DROP TRIGGER IF EXISTS set_end_time_on_victory;
 	DELIMITER $$
 	CREATE TRIGGER set_end_time_on_victory -- We're missing implementation of win

--- a/Anura/js/scenes/bossScene2.js
+++ b/Anura/js/scenes/bossScene2.js
@@ -182,6 +182,17 @@ function drawBossScene2(deltaTime) {
             if (eagleBoss.health <= 0) {
                 eagleBoss = null;
                 isVictory = true; // activate state
+
+            // implemented with AI help, 
+            // calls saveProgress(true) to save victory state to database, AI helped identify that it was 
+            // needed to pass 'true' ad a parameter to indicate victory (not death)
+            // related to changes in app_anura.js /run/death ndpoint, playScene.js saveProgress() function
+            
+            saveProgress(true).then(response => {
+                console.log("Victory saved:", response);
+                sessionMosquitos = response.savedData.mosquitoes_total;
+            });
+
             } else {
                 eagleBoss.draw(ctx);
             }

--- a/Anura/js/scenes/playScene.js
+++ b/Anura/js/scenes/playScene.js
@@ -77,7 +77,7 @@ async function gameOver() {
     console.log("Game Over"); // for debugging
     
     // send death data to backend and WAIT for a reply, front end sends mosquitoes and deck to the backend
-    const response = await saveProgressOnDeath();
+    const response = await saveProgress(false);
     // shows what backend returned in JSON format
     console.log("Backend response:", response);
     sessionMosquitos = response.savedData.mosquitoes_total;
@@ -535,7 +535,7 @@ class DamageNumber {
 
 // GAME OVER async function for API call
 
-async function saveProgressOnDeath() {
+async function saveProgress(isVictory) {
 
     // collect all card IDs from each slot into one array
     const cardIds = [];
@@ -557,7 +557,8 @@ async function saveProgressOnDeath() {
             mosquitoes: runMosquitos,
             run_id: activeRunId,
             deck: cardIds,
-            session_id: activeSessionId
+            session_id: activeSessionId,
+            victory: isVictory // victory added
         })
     });
 

--- a/anura-server/app_anura.js
+++ b/anura-server/app_anura.js
@@ -154,7 +154,7 @@ app.get("/updateAfterPurchase/:session_id", async (req, res) => {
 // When someone sends POST /run/death, run this function:
 app.post("/run/death", async (req, res) => {
     
-    const { mosquitoes, run_id, deck, session_id } = req.body;
+    const { mosquitoes, run_id, deck, session_id, victory } = req.body;
 
     if (!session_id) {
         return res.status(400).json({ error: " a valid run_id is required" });
@@ -162,10 +162,12 @@ app.post("/run/death", async (req, res) => {
 
     try {
         // save the run
-        const bosses_defeated = 0;
-        const victory = false;
-        const runId = await saveRun(run_id, mosquitoes, bosses_defeated, victory);
-
+        // implemented with AI help
+        // added victory parameter handling to support death and victory tracking
+        // AI helped identify that bosses_Defeated should be 2 for victory and 0 for death, it uses a ternary operator victory ? 2 : 0
+        const bosses_defeated = victory ? 2 : 0; // this modification was done with AI for saving the victory boolean true
+        
+        const runId = await saveRun(run_id, mosquitoes, bosses_defeated, victory || false); 
         // get the updated lifetime mosquito total
         const mosquitoData = await getTotalMosquitoesByUser(session_id);
 

--- a/anura-server/db.js
+++ b/anura-server/db.js
@@ -339,7 +339,10 @@ export async function getBestTimeByUser(user_id) {
         SELECT MIN(R.run_time) AS bestTime
         FROM runs AS R
         INNER JOIN sessions AS S ON R.run_session_id = S.session_id
-        WHERE S.session_user_id = ? AND R.victory = TRUE;
+        WHERE S.session_user_id = ? 
+        AND R.victory = TRUE
+        AND R.run_time IS NOT NULL
+        AND R.run_time > 0;
         `, [user_id]);
 
     console.log("Best time for user_id", user_id, ":", rows[0]);


### PR DESCRIPTION
New Trigger
- Added `calculateRunTimeOnUpdate` trigger to calculate run_time on UPDATE (not just INSERT)
- Modified `getBestTimeByUser()` query to ignore and filter run time values and only use the ones > 0
- Added 4 new query functions for user stats:
  - `getUserStatsById()` - Total runs per user
  - `getTotalWinsByUser()` - Count victories
  - `getTotalDeathsByUser()` - Count deaths  
  - `getBestTimeByUser()` - Fastest victory time
  - Updated `POST /run/death/ ` endpoint to accept the victory parameter so it now checks game over and victory
  - modified enfpoint to set bosses_defeated = 2 on victory and 0 on death
  - `saveProgressOnDeath()` is now `saveProgress(isVictory)` so it can handle both 
  - `saveProgress(true)` called when eagle boss defeated
  - `saveProgress(false)` called on game over
  - the stats sidebar gets updated after death/victory with `loadUserStats()`

MAKE SURE TO RUN THE TRIGGER 